### PR TITLE
Fix technologies and branding

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,1 @@
-{ "presets": [ "es2015" ] }
+{ "presets": [ "es2015", "react" ] }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,12 @@ Neta encourages and welcomes contributing as long as you follow our guidelines a
 ## Prerequisites (What you should know)
 Neta is built on many technologies, some of which you may need to know when wanting to contribute.  We want Neta to be well-made, so we are pretty strict about pull requests!
 
-Here is a list of some widespread things in Campefire (in no particular order):
+Here is a list of some widespread things in Neta (in no particular order):
  - [ES2015](https://babeljs.io/docs/learn-es2015/) (JavaScript)
  - [Electron](http://electron.atom.io/)
  - [NodeJS](http://nodejs.org/)
  - [Stylus](http://stylus-lang.com/)
- - [Vue](http://vuejs.org/)
+ - [React](http://facebook.github.io/react/)
 
 ## Guidelines
 Our guidelines are _config-form_, we use [eslint](.eslintrc.json) to keep a consistent style throughout the code, to keep it neat.  Remember to always lint your code when making a contribution!

--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
   "dependencies": {
     "babel-core": "^6.3.17",
     "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "babel-register": "^6.3.13",
-    "stylus": "^0.53.0",
-    "swig": "^1.4.2",
-    "vue": "^1.0.11"
+    "stylus": "^0.53.0"
   },
   "devDependencies": {
     "electron-packager": "^5.1.1",


### PR DESCRIPTION
Since we're switching from Vue to React and removing Swig temporarily, I fixed a few of the files:
 - `CONTRIBUTING.md`: Fix "Prerequisites" section.
 - `.babelrc`: Add `"react"` preset for JSX parsing.
 - `package.json`: Add `"babel-preset-react"` and remove `"vue"` and `"swig"`

I'm not home currently so I cannot test.  Someone else can test it it and merge this or I can test it when I get home later today (Just need to check if the deps install and if the JSX parsing works).

Fixes #21 